### PR TITLE
Add PassthroughCirceHttpError Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,15 @@ Users of this library can use the `SimpleCirceHttpError` or `SimpleCirceHttpProb
 
 ## http4s Circe ##
 
-The http4s circe module provides a middleware which automatically transforms any `HttpError` or `HttpProblem` types into the appropriate response structures as defined in [rfc-7807][rfc-7807]. Currently it only supports JSON, but XML support is planned.
+The http4s circe module provides middlewares which operate on `HttpError` or `HttpProblem` values.
+
+### CirceHttpErrorToResponse ####
+
+`CirceHttpErrorToResponse` is a server middleware which automatically transforms any `HttpError` or `HttpProblem` types into the appropriate response structures as defined in [rfc-7807][rfc-7807].
+
+### PassthroughCirceHttpError ###
+
+`PassthroughCirceHttpError` is a client middleware which checks for `application/problem+json` responses, and if it finds one decodes it and re-raises it in the current `F` context. You can combine this with `CirceHttpErrorToResponse` in order to have a http service passthrough errors. _Caution_, you should only do this if trust the downstream service which may be generating the `application/problem+json`.
 
 [rfc-7807]: https://tools.ietf.org/html/rfc7807 "RFC 7807"
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val circeGenericA    = "circe-generic"
 lazy val circeRefinedA    = "circe-refined"
 lazy val fs2CoreA         = "fs2-core"
 lazy val http4sCirceA     = "http4s-circe"
+lazy val http4sClientA    = "http4s-client"
 lazy val http4sCoreA      = "http4s-core"
 lazy val http4sServerA    = "http4s-server"
 lazy val ip4sCoreA        = "ip4s-core"
@@ -174,6 +175,7 @@ lazy val `http4s-circe` = project
         circeG          %% circeCoreA    % circeV,
         fs2G            %% fs2CoreA      % fs2V,
         http4sG         %% http4sCirceA  % http4sV,
+        http4sG         %% http4sClientA % http4sV,
         http4sG         %% http4sCoreA   % http4sV,
         http4sG         %% http4sServerA % http4sV,
         refinedG        %% refinedA      % refinedV,

--- a/docs/README.md
+++ b/docs/README.md
@@ -211,7 +211,15 @@ Users of this library can use the `SimpleCirceHttpError` or `SimpleCirceHttpProb
 
 ## http4s Circe ##
 
-The http4s circe module provides a middleware which automatically transforms any `HttpError` or `HttpProblem` types into the appropriate response structures as defined in [rfc-7807][rfc-7807]. Currently it only supports JSON, but XML support is planned.
+The http4s circe module provides middlewares which operate on `HttpError` or `HttpProblem` values.
+
+### CirceHttpErrorToResponse ####
+
+`CirceHttpErrorToResponse` is a server middleware which automatically transforms any `HttpError` or `HttpProblem` types into the appropriate response structures as defined in [rfc-7807][rfc-7807].
+
+### PassthroughCirceHttpError ###
+
+`PassthroughCirceHttpError` is a client middleware which checks for `application/problem+json` responses, and if it finds one decodes it and re-raises it in the current `F` context. You can combine this with `CirceHttpErrorToResponse` in order to have a http service passthrough errors. _Caution_, you should only do this if trust the downstream service which may be generating the `application/problem+json`.
 
 [rfc-7807]: https://tools.ietf.org/html/rfc7807 "RFC 7807"
 

--- a/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/CirceHttpErrorToResponse.scala
+++ b/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/CirceHttpErrorToResponse.scala
@@ -1,11 +1,6 @@
 package io.isomarcte.errors4s.http4s.circe.middleware
 
-import cats.data._
 import cats.effect._
-import cats.implicits._
-import io.isomarcte.errors4s.http._
-import io.isomarcte.errors4s.http4s.circe._
-import org.http4s._
 import org.http4s.server._
 
 object CirceHttpErrorToResponse {
@@ -19,24 +14,9 @@ object CirceHttpErrorToResponse {
     * values. Errors which should not have a `Response` body should be raised
     * as something else, e.g. `Error or `RuntimeException`.
     */
-  def json[F[_]](implicit F: Sync[F]): HttpMiddleware[F] = { (service: HttpRoutes[F]) =>
-    HttpRoutes((request: Request[F]) =>
-      OptionT(
-        service
-          .run(request)
-          .value
-          .recoverWith {
-            case e: HttpError =>
-              F.pure(Some(Response(status = Status(e.status.value)).withEntity(e)(httpErrorJsonEntityEncoder[F])))
-            case e: HttpProblem =>
-              F.pure(
-                Some(
-                  Response(status = e.status.fold(Status.InternalServerError)(value => Status(value)))
-                    .withEntity(e)(httpProblemJsonEntityEncoder[F])
-                )
-              )
-          }
-      )
-    )
-  }
+  @deprecated(
+    message = "Please use io.isomarcte.errors4s.http4s.circe.middleware.server.CirceHttpErrorToResponse",
+    since = "0.0.3"
+  )
+  def json[F[_]](implicit F: Sync[F]): HttpMiddleware[F] = server.CirceHttpErrorToResponse.json[F]
 }

--- a/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/client/PassthroughCirceHttpError.scala
+++ b/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/client/PassthroughCirceHttpError.scala
@@ -1,0 +1,61 @@
+package io.isomarcte.errors4s.http4s.circe.middleware.client
+
+import cats.effect._
+import cats.implicits._
+import fs2.Chunk
+import fs2.Stream
+import io.isomarcte.errors4s.http.circe._
+import org.http4s._
+import org.http4s.circe.jsonOfWithMedia
+import org.http4s.client._
+import org.http4s.client.{Middleware => ClientMiddleware}
+import org.http4s.headers._
+
+/** Middlewares for raising RFC 7807 errors in client responses as errors in
+  * some `F` type.
+  */
+object PassthroughCirceHttpError {
+  private def shouldAttemptDecode(headers: Headers): Boolean =
+    headers.get(`Content-Type`).fold(false)(ct => ct.mediaType === MediaType.application.`problem+json`)
+
+  /** Middleware which looks for RFC 7807 errors by discriminating on the
+    * `Content-Type` header. If that header is `application/problem+json`,
+    * then it will attempt to decode the body as a `ExtensibleCirceHttpProblem`.
+    *
+    * If the `Content-Type` is missing or is any other value this middleware
+    * does nothing to the `Response`.
+    *
+    * If the `Content-Type` ''is'' `application/problem+json`, but the decode
+    * fails this should indicate a malformed `ExtensibleCirceHttpProblem`. In
+    * that case the original `Response` is returned, but it is made
+    * strict. This is necessarily to avoid attempting to re-stream the HTTP
+    * response.
+    */
+  def apply[F[_]](implicit F: Sync[F]): ClientMiddleware[F] = { (client: Client[F]) =>
+    Client[F]((request: Request[F]) =>
+      client
+        .run(request)
+        .evalMap(resp =>
+          if (shouldAttemptDecode(resp.headers)) {
+            resp
+              .body
+              .chunks
+              .foldMonoid(Chunk.instance.algebra[Byte])
+              .compile
+              .lastOrError
+              .flatMap { (strictBody: Chunk[Byte]) =>
+                val strictResp: Response[F] = resp.copy(body = Stream.chunk(strictBody))
+                jsonOfWithMedia[F, ExtensibleCirceHttpProblem](MediaType.application.`problem+json`)
+                  .decode(strictResp, true)
+                  .foldF(
+                    Function.const(F.pure(strictResp)),
+                    (e: ExtensibleCirceHttpProblem) => F.raiseError[Response[F]](e)
+                  )
+              }
+          } else {
+            F.pure(resp)
+          }
+        )
+    )
+  }
+}

--- a/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/server/CirceHttpErrorToResponse.scala
+++ b/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/middleware/server/CirceHttpErrorToResponse.scala
@@ -1,0 +1,34 @@
+package io.isomarcte.errors4s.http4s.circe.middleware.server
+
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import io.isomarcte.errors4s.http._
+import io.isomarcte.errors4s.http4s.circe._
+import org.http4s._
+import org.http4s.server._
+
+object CirceHttpErrorToResponse {
+
+  /** A middleware which catches `HttpError` or `HttpProblem` converts them in
+    * to the appropriate `Response` values. Other `Throwable` values are
+    * ignored, e.g. they are not caught.
+    *
+    * The recommended usage is to have your application raise errors which for
+    * which you intend to return an error `Response` as `HttpError`
+    * values. Errors which should not have a `Response` body should be raised
+    * as something else, e.g. `Error or `RuntimeException`.
+    */
+  def json[F[_]](implicit F: Sync[F]): HttpMiddleware[F] = { (service: HttpRoutes[F]) =>
+    HttpRoutes((request: Request[F]) =>
+      service
+        .run(request)
+        .recoverWith {
+          case e: HttpError =>
+            OptionT.liftF(httpErrorAsResponse[F](e))
+          case e: HttpProblem =>
+            OptionT.liftF(httpProblemAsResponse[F](e))
+        }
+    )
+  }
+}

--- a/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/package.scala
+++ b/http4s-circe/src/main/scala/io/isomarcte/errors4s/http4s/circe/package.scala
@@ -60,4 +60,38 @@ package object circe {
 
   def httpProblemJsonEntityDecoder[F[_]: Sync]: EntityDecoder[F, HttpProblem] =
     simpleHttpProblemJsonEntityDecoder[F].widen
+
+  /** Encode a `HttpError` as a http4s `Response.
+    *
+    * @note This respects `ExtensibleCirceHttpError` so if you have custom
+    *       keys in your `HttpError` then ensure it extends
+    *       `ExtensibleCirceHttpError`, otherwise they will not be detected.
+    */
+  def httpErrorAsResponse[F[_]](e: HttpError)(implicit F: Sync[F]): F[Response[F]] =
+    e match {
+      case e: ExtensibleCirceHttpError =>
+        F.pure(Response(status = Status(e.status.value)).withEntity(e)(circeHttpErrorJsonEntityEncoder[F]))
+      case _ =>
+        F.pure(Response(status = Status(e.status.value)).withEntity(e)(httpErrorJsonEntityEncoder[F]))
+    }
+
+  /** Encode a `HttpProblem` as a http4s `Response.
+    *
+    * @note This respects `ExtensibleCirceHttpProblem` so if you have custom
+    *       keys in your `HttpProblem` then ensure it extends
+    *       `ExtensibleCirceHttpProblem`, otherwise they will not be detected.
+    */
+  def httpProblemAsResponse[F[_]](e: HttpProblem)(implicit F: Sync[F]): F[Response[F]] =
+    e match {
+      case e: ExtensibleCirceHttpProblem =>
+        F.pure(
+          Response(status = e.status.fold(Status.InternalServerError)(value => Status(value)))
+            .withEntity(e)(circeHttpProblemJsonEntityEncoder[F])
+        )
+      case e: HttpProblem =>
+        F.pure(
+          Response(status = e.status.fold(Status.InternalServerError)(value => Status(value)))
+            .withEntity(e)(httpProblemJsonEntityEncoder[F])
+        )
+    }
 }

--- a/http4s-circe/src/test/scala/io/isomarcte/errors4s/http4s/circe/middleware/client/PassthroughCirceHttpErrorTest.scala
+++ b/http4s-circe/src/test/scala/io/isomarcte/errors4s/http4s/circe/middleware/client/PassthroughCirceHttpErrorTest.scala
@@ -1,0 +1,143 @@
+package io.isomarcte.errors4s.http4s.circe.middleware.client
+
+import cats.effect._
+import cats.effect.concurrent._
+import cats.implicits._
+import eu.timepit.refined.types.all._
+import fs2.Chunk
+import fs2.Stream
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.refined._
+import io.circe.syntax._
+import io.isomarcte.errors4s.http._
+import io.isomarcte.errors4s.http.circe._
+import io.isomarcte.errors4s.http4s.circe._
+import java.nio.charset.StandardCharsets
+import org.http4s._
+import org.http4s.client._
+import org.http4s.headers._
+
+final class PassthroughCirceHttpErrorTest extends BaseTest {
+  import PassthroughCirceHttpErrorTest._
+
+  private def bodyAsChunk(value: Response[SyncIO]): SyncIO[Chunk[Byte]] =
+    value.body.chunks.foldMonoid(Chunk.instance.algebra[Byte]).compile.lastOrError
+
+  private def compareResponses(value: Response[SyncIO], expected: Response[SyncIO]): SyncIO[Unit] =
+    SyncIO(value.status shouldBe expected.status) *> SyncIO(value.headers shouldBe expected.headers) *>
+      bodyAsChunk(value)
+        .flatMap(value => bodyAsChunk(expected).flatMap(expected => SyncIO(value shouldBe expected).void))
+
+  "A response with a application/problem+json Content-Type" should "raise an error in F if the body is well formed" in
+    sio {
+      val client: Client[SyncIO] = constClientF(httpErrorAsResponse[SyncIO](testError))
+
+      client
+        .run(testRequest)
+        .use[SyncIO, Unit](resp => SyncIO(fail(s"Expected error, but got $resp")))
+        .attemptT
+        .foldF(
+          e =>
+            e match {
+              case e: ExtensibleCirceHttpProblem =>
+                SyncIO(e.asJson shouldBe testError.asJson)
+              case otherwise =>
+                SyncIO(fail(s"Expected ExtensibleCirceHttpProblem, but got $otherwise"))
+            },
+          value => SyncIO(fail(s"Expected error, but got successful $value"))
+        )
+    }
+
+  it should "yield the original response if parsing fails (e.g. the Content-Type is wrong)" in
+    sio {
+      val client: Client[SyncIO] = constClient(responseWithContentType)
+
+      client.run(testRequest).use[SyncIO, Unit](resp => compareResponses(resp, responseWithContentType))
+    }
+
+  "The PassthroughCirceHttpError middleware" should
+    "only read the body if there is an application/problem+json, and in that case it should only do so once" in
+    sio {
+      Ref
+        .of[SyncIO, Int](0)
+        .flatMap { ref =>
+          val responseBody: String = "Body"
+          val response: Response[SyncIO] = Response(
+            status = Status.Ok,
+            headers = Headers.of(`Content-Type`(MediaType.application.`problem+json`)),
+            body = Stream
+              .evalUnChunk(ref.update(_ + 1) *> SyncIO.pure(Chunk.bytes(responseBody.getBytes(StandardCharsets.UTF_8))))
+          )
+
+          val client: Client[SyncIO] = constClient(response)
+
+          // The result should be _2_ and not _1_ because the body is evaluated
+          // once in the middleware and once again by the `compareResponses`
+          // helper (which uses the original `fs2.Stream` value.
+          client.run(testRequest).use(value => compareResponses(value, response)) *>
+            ref.get.flatMap(value => SyncIO(value shouldBe 2))
+        }
+    }
+
+  it should "not read the body at all if the content-type is not an application/problem+json" in
+    sio {
+      Ref
+        .of[SyncIO, Int](0)
+        .flatMap { ref =>
+          val responseBody: String = "Body"
+          val response: Response[SyncIO] = Response(
+            status = Status.Ok,
+            body = Stream
+              .evalUnChunk(ref.update(_ + 1) *> SyncIO.pure(Chunk.bytes(responseBody.getBytes(StandardCharsets.UTF_8))))
+          )
+
+          val client: Client[SyncIO] = constClient(response)
+
+          client
+            .run(testRequest)
+            .use(value =>
+              // Throw away the body, which should prevent the Ref from ever being
+              // updated if the middleware is working correctly.
+              SyncIO.pure(value.copy(body = Stream.empty))
+            ) *> ref.get.flatMap(value => SyncIO(value shouldBe 0))
+        }
+    }
+}
+
+object PassthroughCirceHttpErrorTest {
+  final private case class CustomCirceHttpError(
+    override val `type`: NonEmptyString,
+    override val title: NonEmptyString,
+    override val status: HttpStatus,
+    override val detail: Option[String],
+    override val instance: Option[NonEmptyString],
+    customInt: Int
+  ) extends ExtensibleCirceHttpError {
+    override lazy val toJson: Json = this.asJson
+  }
+
+  private object CustomCirceHttpError {
+    implicit lazy val c: Codec[CustomCirceHttpError] = deriveCodec
+  }
+
+  private lazy val testError: CustomCirceHttpError = CustomCirceHttpError(
+    NonEmptyString("about:blank"),
+    NonEmptyString("Title"),
+    HttpStatus(501),
+    None,
+    None,
+    1
+  )
+
+  private lazy val testRequest: Request[SyncIO] = Request()
+
+  private lazy val responseWithContentType: Response[SyncIO] = Response(headers =
+    Headers.of(`Content-Type`(MediaType.application.`problem+json`))
+  )
+
+  private def constClientF(response: SyncIO[Response[SyncIO]]): Client[SyncIO] =
+    PassthroughCirceHttpError(Sync[SyncIO])(Client[SyncIO](Function.const(Resource.liftF(response))))
+
+  private def constClient(response: Response[SyncIO]): Client[SyncIO] = constClientF(SyncIO.pure(response))
+}

--- a/http4s-circe/src/test/scala/io/isomarcte/errors4s/http4s/circe/middleware/server/CirceHttpErrorToResponseTest.scala
+++ b/http4s-circe/src/test/scala/io/isomarcte/errors4s/http4s/circe/middleware/server/CirceHttpErrorToResponseTest.scala
@@ -1,4 +1,4 @@
-package io.isomarcte.errors4s.http4s.circe.middleware
+package io.isomarcte.errors4s.http4s.circe.middleware.server
 
 import cats.data._
 import cats.effect._

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.3-23-550c6c0a")

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.3-23-550c6c0a")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.3-23-550c6c0a")


### PR DESCRIPTION
This is a client middleware which will look for `application/problem+json` responses (via the Content-Type header) and if it finds one decode it and raise it as an error in `F`.