### PR TITLE
Weaken The Type Of `detail` To `String`

### DIFF
--- a/http-circe/src/main/scala/io/isomarcte/errors4s/http/circe/ExtensibleCirceHttpError.scala
+++ b/http-circe/src/main/scala/io/isomarcte/errors4s/http/circe/ExtensibleCirceHttpError.scala
@@ -31,7 +31,7 @@ object ExtensibleCirceHttpError {
               override val `type`: NonEmptyString           = sht.`type`
               override val title: NonEmptyString            = sht.title
               override val status: HttpStatus               = sht.status
-              override val detail: Option[NonEmptyString]   = sht.detail
+              override val detail: Option[String]           = sht.detail
               override val instance: Option[NonEmptyString] = sht.instance
               override val toJson: Json                     = hcursor.value
             }

--- a/http/src/main/scala/io/isomarcte/errors4s/http/HttpError.scala
+++ b/http/src/main/scala/io/isomarcte/errors4s/http/HttpError.scala
@@ -45,7 +45,7 @@ trait HttpError extends Error {
     *
     * @see [[https://tools.ietf.org/html/rfc7807#section-3.1]]
     */
-  def detail: Option[NonEmptyString]
+  def detail: Option[String]
 
   /** This SHOULD be a URI reference unique to this instance of the problem.
     *
@@ -53,7 +53,9 @@ trait HttpError extends Error {
     */
   def instance: Option[NonEmptyString]
 
-  final override lazy val primaryErrorMessage: NonEmptyString = detail.getOrElse(title)
+  final override lazy val primaryErrorMessage: NonEmptyString = detail
+    .flatMap(value => NonEmptyString.from(value).toOption)
+    .getOrElse(title)
 }
 
 object HttpError {
@@ -63,7 +65,7 @@ object HttpError {
     override val `type`: NonEmptyString,
     override val title: NonEmptyString,
     override val status: HttpStatus,
-    override val detail: Option[NonEmptyString],
+    override val detail: Option[String],
     override val instance: Option[NonEmptyString]
   ) extends HttpError
 }


### PR DESCRIPTION
`detail` in `HttpError` was formerly modeled as `NonEmptyString`, however in actual use it is often generated via other values at runtime, and thus we can not (statically) guarantee it is a `NonEmptyString`. This would lead to this needlessly messy real world usage,

```scala
val detail = NonEmptyString.from(s"Some thing $thing, is wrong in some context $context").getOrElse(NonEmptyString("This is impossible"))
```

To get rid of this boilerplate, we are weakening the type of `detail` to just `String`. `title` already provides a `NonEmptyString` context to satisfy the `Error` API.