### PR TITLE
Make `getMessage` Use ALL The Error Messages

### DIFF
--- a/core/src/main/scala/io/isomarcte/errors4s/core/Error.scala
+++ b/core/src/main/scala/io/isomarcte/errors4s/core/Error.scala
@@ -93,7 +93,8 @@ trait Error extends RuntimeException {
   final lazy val errorMessages: Vector[String] =
     Vector(primaryErrorMessage.value) ++ secondaryErrorMessages ++ causesErrorMessages
 
-  final override lazy val getMessage: String  = primaryErrorMessage.value
+  final override lazy val getMessage: String = errorMessages.mkString(", ")
+
   final override lazy val getCause: Throwable = causes.headOption.getOrElse(null)
 }
 


### PR DESCRIPTION
Make `getMessage` use ALL the error messages. This ensures that logging systems which rely just on `Throwable#getMessage` correctly log all the error information.