### PR TITLE
Add New Constructors For ResponseError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 
 !/website/siteConfig.js
 !/website/core/Footer.js
+
+/project/project
+/project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -80,12 +80,6 @@ ThisBuild / scalafixDependencies ++= List(organizeImportsG %% organizeImportsA %
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
-ThisBuild / doc / scalacOptions ++=
-  List("-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api")
-ThisBuild / doc / apiMappings ++= {
-  val moduleLink: String => (java.io.File, java.net.URL) = module => ScalaApiDoc.jreModuleLink(jreVersion)(module)
-  Map(moduleLink("java.base"))
-}
 
 // GithubWorkflow
 ThisBuild / githubWorkflowPublishTargetBranches := Nil
@@ -103,7 +97,19 @@ lazy val commonSettings = List(
   scalaVersion := scala213,
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
   addCompilerPlugin(typelevelG    % "kind-projector"     % "0.11.2" cross CrossVersion.full),
-  crossScalaVersions := scalaVersions.toSeq
+  crossScalaVersions := scalaVersions.toSeq,
+  Compile / doc / scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n <= 12 =>
+        List("-no-link-warnings")
+      case _ =>
+        List("-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api")
+    }
+  },
+  Compile / doc / apiMappings ++= {
+    val moduleLink: String => (java.io.File, java.net.URL) = module => ScalaApiDoc.jreModuleLink(jreVersion)(module)
+    Map(moduleLink("java.base"))
+  }
 )
 
 // Mima //

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import ReleaseTransformations._
 import sbt.librarymanagement.VersionNumber
-import io.isomarcte.errors4s.sbt.ScalaApiDoc
+import _root_.io.isomarcte.errors4s.sbt.ScalaApiDoc
 
 // Constants //
 

--- a/build.sbt
+++ b/build.sbt
@@ -80,15 +80,11 @@ ThisBuild / scalafixDependencies ++= List(organizeImportsG %% organizeImportsA %
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
-ThisBuild / doc / scalacOptions ++= List(
-  "-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api"
-)
+ThisBuild / doc / scalacOptions ++=
+  List("-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api")
 ThisBuild / doc / apiMappings ++= {
-  val moduleLink: String => (java.io.File, java.net.URL) =
-    module => ScalaApiDoc.jreModuleLink(jreVersion)(module)
-  Map(
-    moduleLink("java.base")
-  )
+  val moduleLink: String => (java.io.File, java.net.URL) = module => ScalaApiDoc.jreModuleLink(jreVersion)(module)
+  Map(moduleLink("java.base"))
 }
 
 // GithubWorkflow

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
 import ReleaseTransformations._
 import sbt.librarymanagement.VersionNumber
+import io.isomarcte.errors4s.sbt.ScalaApiDoc
 
 // Constants //
 
 lazy val isomarcteOrg  = "io.isomarcte"
+lazy val jreVersion    = "15"
 lazy val projectName   = "errors4s"
 lazy val projectUrl    = url("https://github.com/isomarcte/errors4s")
 lazy val scala212      = "2.12.12"
@@ -78,6 +80,16 @@ ThisBuild / scalafixDependencies ++= List(organizeImportsG %% organizeImportsA %
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+ThisBuild / doc / scalacOptions ++= List(
+  "-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api"
+)
+ThisBuild / doc / apiMappings ++= {
+  val moduleLink: String => (java.io.File, java.net.URL) =
+    module => ScalaApiDoc.jreModuleLink(jreVersion)(module)
+  Map(
+    moduleLink("java.base")
+  )
+}
 
 // GithubWorkflow
 ThisBuild / githubWorkflowPublishTargetBranches := Nil

--- a/project/ScalaApiDoc.scala
+++ b/project/ScalaApiDoc.scala
@@ -1,0 +1,10 @@
+package io.isomarcte.errors4s.sbt
+
+import java.io.File
+import java.net.URL
+
+object ScalaApiDoc {
+
+  def jreModuleLink(jreVersion: String)(module: String): (File, URL) =
+    new File(s"/module/${module}") -> new URL(s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api/${module}")
+}

--- a/project/ScalaApiDoc.scala
+++ b/project/ScalaApiDoc.scala
@@ -6,5 +6,6 @@ import java.net.URL
 object ScalaApiDoc {
 
   def jreModuleLink(jreVersion: String)(module: String): (File, URL) =
-    new File(s"/module/${module}") -> new URL(s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api/${module}")
+    new File(s"/module/${module}") ->
+      new URL(s"https://docs.oracle.com/en/java/javase/${jreVersion}/docs/api/${module}")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.4.5

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.6-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
This commit adds two new construction functions for `ResponseError`.

They both now take a full `Request` value, which is expected to yield better ergonomics. Additionally, the `from_` returns a `F[ResponseError]` rather than a `F[Throwable]`, while `from` returns `F[Throwable]`. Having both types exposed is expected to make it more simple to integrate this into various APIs.