### PR TITLE
Remove Release Plugin

### DIFF
--- a/.github/workflows/jabba-info.yaml
+++ b/.github/workflows/jabba-info.yaml
@@ -12,7 +12,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  build:
+  jabba-info:
     name: Jabba Info
     strategy:
       matrix:

--- a/.github/workflows/release-script-test.yaml
+++ b/.github/workflows/release-script-test.yaml
@@ -2,7 +2,7 @@
 # specific version of Scala to run and there is a Scalafmt bug in the
 # latest 3.0.0-RC which prevents it from running on Scala 3.
 
-name: Scalafmt/Scalafix
+name: Release Script Test
 
 on:
   pull_request:
@@ -14,11 +14,13 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  lint:
-    name: Scalafmt/Scalafix
+  release-dry-run:
+    name: Release Script dry run
+    env:
+      DRY_RUN: 1
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         scala: [2.13.6]
         java: [adopt@1.16]
     runs-on: ${{ matrix.os }}
@@ -45,4 +47,4 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - run: sbt ++${{ matrix.scala }} ';scalafmtCheckAll;scalafix --check'
+      - run: ./release.sh

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import ReleaseTransformations._
 import _root_.io.isomarcte.sbt.version.scheme.enforcer.core._
 import _root_.org.errors4s.sbt.GAVs._
 import _root_.org.errors4s.sbt._
@@ -42,7 +41,7 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 // Baseline version for repo split
 
-ThisBuild / versionSchemeEnforcerIntialVersion := Some("1.0.0.0")
+ThisBuild / versionSchemeEnforcerInitialVersion := Some("1.0.0.0")
 ThisBuild / versionScheme := Some("pvp")
 
 // GithubWorkflow

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,6 @@ addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"                       
 addSbtPlugin("com.codecommit"            % "sbt-github-actions"                 % "0.11.0")
 addSbtPlugin("com.eed3si9n"              % "sbt-unidoc"                         % "0.4.3")
 addSbtPlugin("com.github.cb372"          % "sbt-explicit-dependencies"          % "0.2.16")
-addSbtPlugin("com.github.gseitz"         % "sbt-release"                        % "1.0.13")
 addSbtPlugin("com.jsuereth"              % "sbt-pgp"                            % "2.1.1")
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"                        % "0.5.3")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"                       % "0.1.17")

--- a/release.sh
+++ b/release.sh
@@ -33,7 +33,7 @@ then
         if [ -d "$ORIGIN_PATH" ]
         then
             mkdir -vp "$TARGET_PATH"
-            cp -bRv "${ORIGIN_PATH}/"* "$TARGET_PATH"
+            cp -Rv "${ORIGIN_PATH}/"* "$TARGET_PATH"
         else
             continue
         fi

--- a/release.sh
+++ b/release.sh
@@ -47,14 +47,17 @@ fi
 readonly FAKE_HOME
 export HOME="${FAKE_HOME}"
 
+# JVM Options #
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Duser.home=${FAKE_HOME}"
+
 # Release #
 
 if git update-index --refresh && git diff-index --quiet @ -- || [ "$DRY_RUN" -ne 0 ]
 then
     # Publish locally first for the scripted tests.
-    sbt --ivy "${FAKE_HOME}/.ivy2" --sbt-dir "${FAKE_HOME}/.sbt" --sbt-boot "${FAKE_HOME}/.sbt/boot" '+clean'
-    sbt --ivy "${FAKE_HOME}/.ivy2" --sbt-dir "${FAKE_HOME}/.sbt" --sbt-boot "${FAKE_HOME}/.sbt/boot" '+publishLocal'
-    sbt --ivy "${FAKE_HOME}/.ivy2" --sbt-dir "${FAKE_HOME}/.sbt" --sbt-boot "${FAKE_HOME}/.sbt/boot" +';scalafixAll --check;scalafmtSbtCheck;scalafmtCheckAll;test;test:doc;'
+    sbt '+clean'
+    sbt '+publishLocal'
+    sbt +';scalafixAll --check;scalafmtSbtCheck;scalafmtCheckAll;test;test:doc;'
 
     # Exit here on DRY_RUN
     if [ "$DRY_RUN" -ne 0 ]


### PR DESCRIPTION
It is replaced with a bash script

Also updates the deprecated `versionSchemeEnforcerIntialVersion` key to `versionSchemeEnforcerInitialVersion`.
Also renames some CI jobs to be more descriptive.