### PR TITLE
Updates And Use Scala 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        scala: [2.12.14, 2.13.7, 3.1.0]
-        java: [openjdk@1.17.0, openjdk@1.16.0, adopt@1.8]
+        scala: [2.12.15, 2.13.7, 3.0.2]
+        java: [temurin@17, temurin@11, temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,10 +31,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ lazy val org           = "org.errors4s"
 lazy val jreVersion    = "17"
 lazy val projectName   = "errors4s-core"
 lazy val projectUrl    = url(s"https://github.com/errors4s/${projectName}")
-lazy val scala212      = "2.12.14"
+lazy val scala212      = "2.12.15"
 lazy val scala213      = "2.13.7"
-lazy val scala3        = "3.1.0"
+lazy val scala3        = "3.0.2"
 lazy val scalaVersions = Set(scala212, scala213, scala3)
 
 // SBT Command Aliases //
@@ -59,7 +59,8 @@ ThisBuild / versionScheme                       := Some("pvp")
 // GithubWorkflow
 ThisBuild / githubWorkflowPublishTargetBranches := Nil
 ThisBuild / githubWorkflowOSes                  := Set("macos-latest", "ubuntu-latest").toList
-ThisBuild / githubWorkflowJavaVersions          := Set("openjdk@1.17.0", "openjdk@1.16.0", "adopt@1.8").toList
+ThisBuild / githubWorkflowJavaVersions :=
+  Set("17", "11", "8").map(version => JavaSpec(JavaSpec.Distribution.Temurin, version)).toList
 ThisBuild / githubWorkflowBuild := List(WorkflowStep.Sbt(List("versionSchemeEnforcerCheck", "Test / doc")))
 
 // Doc Settings

--- a/core/src/main/scala-3/org/errors4s/core/NonEmptyString.scala
+++ b/core/src/main/scala-3/org/errors4s/core/NonEmptyString.scala
@@ -108,7 +108,7 @@ object NonEmptyString {
     expr
       .value
       .fold(
-        report.errorAndAbort(
+        report.throwError(
           "String value is not a literal constant. If at least part of the String is a literal constant, you can use the `nes` String interpolator. You can access it by import org.errors4s.core.syntax.all.*"
         )
       ) {

--- a/docs-src/README.md
+++ b/docs-src/README.md
@@ -165,9 +165,7 @@ If you need support for a version combination which is not listed here, please o
 
 |Version|Cats Version|Scalacheck Version|Scala 2.11|Scala 2.12|Scala 2.13|Scala 3.0|Scala 3.1|
 |-------|:----------:|:----------------:|:--------:|:--------:|:--------:|:-------:|:-------:|
-|1.0.x.x|2.x.x       |1.x.x (>= 1.15.x) |No        |Yes       |Yes       |No       |Yes      |
-
-Note, as of 2021-11-18 this project targets Scala 3.1.0 for the Scala 3.x version, which is not backwards compatible with Scala 3.0.
+|1.0.x.x|2.x.x       |1.x.x (>= 1.15.x) |No        |Yes       |Yes       |Yes      |Yes      |
 
 # Versioning #
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,9 +177,7 @@ If you need support for a version combination which is not listed here, please o
 
 |Version|Cats Version|Scalacheck Version|Scala 2.11|Scala 2.12|Scala 2.13|Scala 3.0|Scala 3.1|
 |-------|:----------:|:----------------:|:--------:|:--------:|:--------:|:-------:|:-------:|
-|1.0.x.x|2.x.x       |1.x.x (>= 1.15.x) |No        |Yes       |Yes       |No       |Yes      |
-
-Note, as of 2021-11-18 this project targets Scala 3.1.0 for the Scala 3.x version, which is not backwards compatible with Scala 3.0.
+|1.0.x.x|2.x.x       |1.x.x (>= 1.15.x) |No        |Yes       |Yes       |Yes      |Yes      |
 
 # Versioning #
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"                       % "0.9.32")
-addSbtPlugin("com.codecommit"            % "sbt-github-actions"                 % "0.13.0")
+addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"                       % "0.9.33")
+addSbtPlugin("com.codecommit"            % "sbt-github-actions"                 % "0.14.2")
 addSbtPlugin("com.eed3si9n"              % "sbt-unidoc"                         % "0.4.3")
 addSbtPlugin("com.github.cb372"          % "sbt-explicit-dependencies"          % "0.2.16")
 addSbtPlugin("com.jsuereth"              % "sbt-pgp"                            % "2.1.1")
@@ -7,4 +7,4 @@ addSbtPlugin("com.timushev.sbt"          % "sbt-updates"                        
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"                       % "0.1.20")
 addSbtPlugin("io.isomarcte"              % "sbt-version-scheme-enforcer-plugin" % "2.1.0.3")
 addSbtPlugin("org.scalameta"             % "sbt-mdoc"                           % "2.2.24")
-addSbtPlugin("org.scalameta"             % "sbt-scalafmt"                       % "2.4.3")
+addSbtPlugin("org.scalameta"             % "sbt-scalafmt"                       % "2.4.5")


### PR DESCRIPTION
Since Scala 3.0 is bincompat with Scala 3.1, we are downgrading to Scala 3.0